### PR TITLE
chore: use released crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9112,9 +9112,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,30 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "account-compression"
-version = "2.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
-dependencies = [
- "aligned-sized",
- "anchor-lang",
- "bytemuck",
- "light-account-checks",
- "light-batched-merkle-tree",
- "light-bounded-vec",
- "light-compressed-account",
- "light-concurrent-merkle-tree",
- "light-hash-set",
- "light-hasher",
- "light-indexed-merkle-tree",
- "light-merkle-tree-metadata",
- "light-zero-copy",
- "num-bigint 0.4.6",
- "solana-sdk",
- "solana-security-txt",
- "zerocopy",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,7 +126,8 @@ dependencies = [
 [[package]]
 name = "aligned-sized"
 version = "1.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a526ec4434d531d488af59fe866f36b310fe8906691c75dffa664450a3800a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -255,28 +232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-compressed-token"
-version = "2.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
-dependencies = [
- "account-compression",
- "anchor-lang",
- "anchor-spl",
- "light-compressed-account",
- "light-hasher",
- "light-heap",
- "light-system-program-anchor",
- "light-token-interface",
- "light-zero-copy",
- "pinocchio-pubkey",
- "solana-sdk",
- "solana-security-txt",
- "spl-token 7.0.0",
- "spl-token-2022 7.0.0",
- "zerocopy",
-]
-
-[[package]]
 name = "anchor-derive-accounts"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,21 +313,6 @@ checksum = "2bdf143115440fe621bdac3a29a1f7472e09f6cd82b2aa569429a0c13f103838"
 dependencies = [
  "anyhow",
  "serde",
-]
-
-[[package]]
-name = "anchor-spl"
-version = "0.31.1"
-source = "git+https://github.com/lightprotocol/anchor?rev=da005d7f#da005d7f1f977d5220eaa65da26cdae2df0fe25e"
-dependencies = [
- "anchor-lang",
- "spl-associated-token-account 6.0.0",
- "spl-memo",
- "spl-pod",
- "spl-token 7.0.0",
- "spl-token-2022 6.0.0",
- "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface 0.6.0",
 ]
 
 [[package]]
@@ -2505,9 +2445,9 @@ dependencies = [
 [[package]]
 name = "light-account-checks"
 version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0785da22cd4a7667583141ca56c790a5c8afa2b22ad2a08204d78881035524e8"
 dependencies = [
- "pinocchio",
  "solana-account-info",
  "solana-msg",
  "solana-program-error",
@@ -2517,28 +2457,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-anchor-spl"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c802e3de6de4bb03bc9e9bacbba8aa94823a083046aaf0ef275b1321984e3"
+dependencies = [
+ "anchor-lang",
+ "spl-associated-token-account 6.0.0",
+ "spl-memo",
+ "spl-pod",
+ "spl-token 7.0.0",
+ "spl-token-2022 6.0.0",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
+]
+
+[[package]]
 name = "light-array-map"
 version = "0.1.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859dc5b406a8bf0b114f686e6f2e36d0e939bad6f579492a520d309b52fde1f8"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "light-batched-merkle-tree"
-version = "0.7.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13cb8bc778065ee71d1990fdc94112e35dc63a5e387a323284a49f40d123d8e0"
 dependencies = [
  "aligned-sized",
  "borsh 0.10.4",
  "light-account-checks",
  "light-bloom-filter",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "light-hasher",
  "light-macros",
  "light-merkle-tree-metadata",
  "light-verifier",
- "light-zero-copy",
+ "light-zero-copy 0.6.0",
  "solana-account-info",
  "solana-msg",
  "solana-program-error",
@@ -2551,7 +2509,8 @@ dependencies = [
 [[package]]
 name = "light-bloom-filter"
 version = "0.5.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a609e3c9179f0ae8488cc70c5413c86dfd97dad7ad85fee2ad8da2d0a11e61"
 dependencies = [
  "bitvec",
  "num-bigint 0.4.6",
@@ -2574,8 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.17.2"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1f3cd013364dbe5c45a9e9a8faee1af30dccb600cd56a41e296ed8d5684768"
 dependencies = [
  "anchor-lang",
  "async-trait",
@@ -2584,7 +2544,7 @@ dependencies = [
  "bs58",
  "futures",
  "lazy_static",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "light-compressible",
  "light-concurrent-merkle-tree",
  "light-event",
@@ -2593,8 +2553,8 @@ dependencies = [
  "light-merkle-tree-metadata",
  "light-prover-client",
  "light-sdk",
+ "light-token",
  "light-token-interface",
- "light-token-sdk",
  "litesvm",
  "num-bigint 0.4.6",
  "photon-api",
@@ -2629,7 +2589,24 @@ dependencies = [
 [[package]]
 name = "light-compressed-account"
 version = "0.7.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058df2733fa6a3e4bda6f162a6c5d41f10fc8c6f6ddb992af1de76b60214e4a6"
+dependencies = [
+ "borsh 0.10.4",
+ "light-hasher",
+ "light-macros",
+ "light-program-profiler",
+ "light-zero-copy 0.5.0",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "zerocopy",
+]
+
+[[package]]
+name = "light-compressed-account"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "768ae5a56d8c9cf315d132b3faa5b067f95b3d6a294c579e82f8f0e0bf29c7cc"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
@@ -2638,8 +2615,7 @@ dependencies = [
  "light-macros",
  "light-poseidon 0.3.0",
  "light-program-profiler",
- "light-zero-copy",
- "pinocchio",
+ "light-zero-copy 0.6.0",
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
@@ -2649,59 +2625,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-compressed-token"
-version = "2.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
-dependencies = [
- "account-compression",
- "anchor-compressed-token",
- "anchor-lang",
- "arrayvec",
- "bitvec",
- "borsh 0.10.4",
- "light-account-checks",
- "light-array-map",
- "light-compressed-account",
- "light-compressible",
- "light-hasher",
- "light-heap",
- "light-program-profiler",
- "light-sdk",
- "light-sdk-pinocchio",
- "light-sdk-types",
- "light-system-program-anchor",
- "light-token-interface",
- "light-zero-copy",
- "pinocchio",
- "pinocchio-pubkey",
- "pinocchio-system",
- "pinocchio-token-program",
- "solana-pubkey",
- "solana-security-txt",
- "spl-pod",
- "spl-token 7.0.0",
- "spl-token-2022 7.0.0",
- "tinyvec",
- "zerocopy",
-]
-
-[[package]]
 name = "light-compressible"
-version = "0.2.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff0f0065beb8d16df587b3ea17082e11dea3f67c98813b4bcc061eecd94561f"
 dependencies = [
  "aligned-sized",
  "anchor-lang",
  "borsh 0.10.4",
  "bytemuck",
  "light-account-checks",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "light-hasher",
  "light-macros",
  "light-program-profiler",
  "light-sdk-types",
- "light-zero-copy",
- "pinocchio",
+ "light-zero-copy 0.6.0",
  "pinocchio-pubkey",
  "solana-pubkey",
  "thiserror 2.0.18",
@@ -2711,7 +2650,8 @@ dependencies = [
 [[package]]
 name = "light-concurrent-merkle-tree"
 version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db96f47253a0907aaa46dac15cecb27b5510130e48da0b36690dcd2e99a6d558"
 dependencies = [
  "borsh 0.10.4",
  "light-bounded-vec",
@@ -2723,32 +2663,22 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.2.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674c9d85b32a9e8abb90cccdee18e35ae29daa1126fdb81a8a28c0a54802096"
 dependencies = [
  "borsh 0.10.4",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "light-hasher",
- "light-zero-copy",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "light-hash-set"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
-dependencies = [
- "light-hasher",
- "num-bigint 0.4.6",
- "num-traits",
- "solana-program-error",
+ "light-zero-copy 0.6.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "light-hasher"
 version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c822662e6e109bac0e132a43fd52a4ef684811245a794e048cf9cda001e934c8"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -2763,17 +2693,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-heap"
-version = "2.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
-dependencies = [
- "anchor-lang",
-]
-
-[[package]]
 name = "light-indexed-array"
 version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f14f984030d86b6f07bd8f5ae04e2c40fcd0c3bdfcc7a291fff1ed59c9e6554"
 dependencies = [
  "light-hasher",
  "num-bigint 0.4.6",
@@ -2784,7 +2707,8 @@ dependencies = [
 [[package]]
 name = "light-indexed-merkle-tree"
 version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0824755289075f28de2820fc7d4ec4e6b9e99d404e033c07338b91cce8c71fb8"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2799,7 +2723,8 @@ dependencies = [
 [[package]]
 name = "light-macros"
 version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179ac51cadc1d0ca047b4d6265a7cc245ca3affc16a20a2749585aa6464d39c2"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2810,13 +2735,14 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.7.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d08edcc194eef61b0f499934ce398122d54ac57505d44480e5f079a4220566"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
  "bytemuck",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "solana-msg",
  "solana-program-error",
  "solana-sysvar",
@@ -2827,7 +2753,8 @@ dependencies = [
 [[package]]
 name = "light-merkle-tree-reference"
 version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d480f62ca32b38a6231bbc5310d693f91d6b5bdcc18bb13c2d9aab7a1c90e8"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2882,10 +2809,10 @@ dependencies = [
 
 [[package]]
 name = "light-program-test"
-version = "0.17.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a981dfbc19c529543ab1dd8d100319b89aac053b81415a681d1474c986218307"
 dependencies = [
- "account-compression",
  "anchor-lang",
  "async-trait",
  "base64 0.13.1",
@@ -2893,12 +2820,9 @@ dependencies = [
  "bs58",
  "bytemuck",
  "chrono",
- "light-batched-merkle-tree",
  "light-client",
- "light-compressed-account",
- "light-compressed-token",
+ "light-compressed-account 0.8.0",
  "light-compressible",
- "light-concurrent-merkle-tree",
  "light-event",
  "light-hasher",
  "light-indexed-array",
@@ -2906,12 +2830,11 @@ dependencies = [
  "light-merkle-tree-metadata",
  "light-merkle-tree-reference",
  "light-prover-client",
- "light-registry",
  "light-sdk",
  "light-sdk-types",
+ "light-token",
  "light-token-interface",
- "light-token-sdk",
- "light-zero-copy",
+ "light-zero-copy 0.6.0",
  "litesvm",
  "log",
  "num-bigint 0.4.6",
@@ -2939,12 +2862,13 @@ dependencies = [
 [[package]]
 name = "light-prover-client"
 version = "5.0.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75d8c9b8b6e9d445b9ef27467da592ee231e614282c3c0bd2f30f567eb904845"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
- "light-compressed-account",
+ "light-compressed-account 0.7.0",
  "light-hasher",
  "light-indexed-array",
  "light-sparse-merkle-tree",
@@ -2960,47 +2884,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-registry"
-version = "2.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
-dependencies = [
- "account-compression",
- "aligned-sized",
- "anchor-lang",
- "borsh 0.10.4",
- "light-account-checks",
- "light-batched-merkle-tree",
- "light-compressible",
- "light-macros",
- "light-merkle-tree-metadata",
- "light-program-profiler",
- "light-system-program-anchor",
- "light-token-interface",
- "light-zero-copy",
- "solana-account-info",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk",
- "solana-security-txt",
- "spl-pod",
-]
-
-[[package]]
 name = "light-sdk"
-version = "0.17.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dece106ebd0897bd23a12bad040e0999d93b54447d0473739f91b1f83b1d331"
 dependencies = [
  "anchor-lang",
  "bincode",
  "borsh 0.10.4",
  "light-account-checks",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "light-compressible",
  "light-hasher",
  "light-macros",
  "light-sdk-macros",
  "light-sdk-types",
- "light-zero-copy",
+ "light-zero-copy 0.6.0",
  "num-bigint 0.4.6",
  "solana-account-info",
  "solana-clock",
@@ -3008,6 +2907,7 @@ dependencies = [
  "solana-instruction",
  "solana-loader-v3-interface",
  "solana-msg",
+ "solana-program",
  "solana-program-error",
  "solana-pubkey",
  "solana-system-interface",
@@ -3017,8 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.17.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d91992fa08093b1a274b3baed1d8368de794cc2645f9942718e5fe47a27dc2"
 dependencies = [
  "darling",
  "light-hasher",
@@ -3030,30 +2931,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-sdk-pinocchio"
-version = "0.17.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
-dependencies = [
- "borsh 0.10.4",
- "light-account-checks",
- "light-compressed-account",
- "light-hasher",
- "light-macros",
- "light-sdk-macros",
- "light-sdk-types",
- "pinocchio",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "light-sdk-types"
-version = "0.17.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b765f0a39428a137b8d449fa60ba147194cdbff08aa0add598c6047fff2cb7d2"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
  "light-account-checks",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "light-hasher",
  "light-macros",
  "solana-msg",
@@ -3063,7 +2949,8 @@ dependencies = [
 [[package]]
 name = "light-sparse-merkle-tree"
 version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4251e79b6c63f4946572dcfd7623680ad0f9e0efe1a761a944733333c5645063"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -3073,34 +2960,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-system-program-anchor"
-version = "2.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+name = "light-token"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62907a12a9801200e5f4c03bb7f2dbdd9aa679223a959167c456a06005291d79"
 dependencies = [
- "account-compression",
- "aligned-sized",
  "anchor-lang",
- "light-compressed-account",
- "light-zero-copy",
- "zerocopy",
+ "arrayvec",
+ "borsh 0.10.4",
+ "light-account-checks",
+ "light-batched-merkle-tree",
+ "light-compressed-account 0.8.0",
+ "light-compressible",
+ "light-macros",
+ "light-program-profiler",
+ "light-sdk",
+ "light-sdk-macros",
+ "light-sdk-types",
+ "light-token-interface",
+ "light-token-types",
+ "light-zero-copy 0.6.0",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-pod",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "light-token-interface"
-version = "0.1.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb19b8e268a0154a8e13b3a8f6f43fa4928643e2de102d98a90b2af21f482ba"
 dependencies = [
  "aligned-sized",
  "anchor-lang",
  "borsh 0.10.4",
  "bytemuck",
  "light-array-map",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "light-compressible",
  "light-hasher",
  "light-macros",
  "light-program-profiler",
- "light-zero-copy",
+ "light-zero-copy 0.6.0",
  "pinocchio",
  "pinocchio-pubkey",
  "solana-account-info",
@@ -3113,45 +3019,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-token-sdk"
-version = "0.2.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
-dependencies = [
- "anchor-lang",
- "anchor-spl",
- "arrayvec",
- "borsh 0.10.4",
- "light-account-checks",
- "light-batched-merkle-tree",
- "light-compressed-account",
- "light-compressible",
- "light-macros",
- "light-program-profiler",
- "light-sdk",
- "light-sdk-macros",
- "light-sdk-types",
- "light-token-interface",
- "light-token-types",
- "light-zero-copy",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-pod",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "light-token-types"
-version = "0.2.1"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "278dddbf18d104f1225c480ca6d7b8710e1f9ff4104f24be70c522ecb6ed1dfc"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
  "light-account-checks",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "light-macros",
  "light-sdk-types",
  "solana-msg",
@@ -3160,20 +3036,32 @@ dependencies = [
 
 [[package]]
 name = "light-verifier"
-version = "6.0.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f35f47736be493b60d8b56ef0c8e94afd6a99efafebb257f62b0b545e9aacab"
 dependencies = [
  "groth16-solana",
- "light-compressed-account",
+ "light-compressed-account 0.8.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "light-zero-copy"
 version = "0.5.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8862f463792fd60ae8f5dc418150c16213e302e19d54fba0694cf8515be5ff"
 dependencies = [
- "light-zero-copy-derive",
+ "light-zero-copy-derive 0.5.0",
+ "zerocopy",
+]
+
+[[package]]
+name = "light-zero-copy"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5621fb515e14af46148699c0b65334aabe230a1d2cbd06736ccc7a408c8a4af"
+dependencies = [
+ "light-zero-copy-derive 0.6.0",
  "solana-program-error",
  "zerocopy",
 ]
@@ -3181,7 +3069,20 @@ dependencies = [
 [[package]]
 name = "light-zero-copy-derive"
 version = "0.5.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af086d52100b3cab1f2993b146adc7a69fa6aaa878ae4c19514c77c50304379"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "light-zero-copy-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41c46425e5c7ab5203ff5c86ae2615b169cca55f9283f5f60f5dd74143be6934"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -3658,8 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "photon-api"
-version = "0.53.0"
-source = "git+https://github.com/Lightprotocol/light-protocol?rev=5013dbe2f2abc77984a2801e69b5c46453962b31#5013dbe2f2abc77984a2801e69b5c46453962b31"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e572dba0c255f5b8176f15b9e849330d915a8927804f7f9702d5bbbc70e4a1ad"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -3709,12 +3611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b971851087bc3699b001954ad02389d50c41405ece3548cbcafc88b3e20017a"
 
 [[package]]
-name = "pinocchio-log"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd11022408f312e6179ece321c1f7dc0d1b2aa7765fddd39b2a7378d65a899e8"
-
-[[package]]
 name = "pinocchio-pubkey"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,35 +3619,6 @@ dependencies = [
  "five8_const",
  "pinocchio",
  "sha2-const-stable",
-]
-
-[[package]]
-name = "pinocchio-system"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141ed5eafb4ab04568bb0e224e3dc9a9de13c933de4c004e0d1a553498be3a7c"
-dependencies = [
- "pinocchio",
- "pinocchio-pubkey",
-]
-
-[[package]]
-name = "pinocchio-token-interface"
-version = "0.0.0"
-source = "git+https://github.com/Lightprotocol/token?rev=9ea04560a039d1a44f0411b5eaa7c0b79ed575ab#9ea04560a039d1a44f0411b5eaa7c0b79ed575ab"
-dependencies = [
- "pinocchio",
- "pinocchio-pubkey",
-]
-
-[[package]]
-name = "pinocchio-token-program"
-version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/token?rev=9ea04560a039d1a44f0411b5eaa7c0b79ed575ab#9ea04560a039d1a44f0411b5eaa7c0b79ed575ab"
-dependencies = [
- "pinocchio",
- "pinocchio-log",
- "pinocchio-token-interface",
 ]
 
 [[package]]
@@ -4101,10 +3968,12 @@ dependencies = [
  "bincode",
  "blake3",
  "bytemuck",
+ "light-anchor-spl",
  "light-client",
+ "light-hasher",
  "light-program-test",
  "light-sdk",
- "light-token-sdk",
+ "light-token",
  "proptest",
  "quickcheck",
  "rand 0.9.2",

--- a/programs/cp-swap/Cargo.toml
+++ b/programs/cp-swap/Cargo.toml
@@ -19,7 +19,7 @@ enable-log = []
 devnet = []
 client = []
 anchor-debug = []
-idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build", "light-token-sdk/idl-build"]
+idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build", "light-token/idl-build", "light-anchor-spl/idl-build"]
 test-sbf = []
 
 [dependencies]
@@ -32,8 +32,10 @@ bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"] }
 arrayref = { version = "0.3.6" }
 blake3 = { workspace = true }
 
-light-sdk = { git = "https://github.com/Lightprotocol/light-protocol", rev = "5013dbe2f2abc77984a2801e69b5c46453962b31", features = ["anchor", "anchor-discriminator", "v2", "idl-build", "cpi-context"] }
-light-token-sdk = { git = "https://github.com/Lightprotocol/light-protocol", rev = "5013dbe2f2abc77984a2801e69b5c46453962b31", features = ["anchor", "idl-build", "anchor-spl-memo", "anchor-spl-associated-token"] }
+light-sdk = { version = "0.18.0", features = ["anchor", "anchor-discriminator", "idl-build", "cpi-context"] }
+light-token = { version = "0.3.0", features = ["anchor", "idl-build"] }
+light-hasher = "5"
+light-anchor-spl = { version = "0.31.1", features = ["idl-build", "memo"] }
 solana-account-info = "2.3"
 solana-program = "2.2"
 solana-pubkey = "2.2"
@@ -46,8 +48,8 @@ quickcheck = "1.0.3"
 proptest = "1.0"
 rand = "0.9.0"
 
-light-program-test = { git = "https://github.com/Lightprotocol/light-protocol", rev = "5013dbe2f2abc77984a2801e69b5c46453962b31", features = ["v2", "devenv"] }
-light-client = { git = "https://github.com/Lightprotocol/light-protocol", rev = "5013dbe2f2abc77984a2801e69b5c46453962b31", features = ["v2"] }
+light-program-test = { version = "0.18.0" }
+light-client = { version = "0.18.0" }
 tokio = { version = "1", features = ["full"] }
 spl-token = "7.0.0"
 solana-keypair = { version = "2.2" }

--- a/programs/cp-swap/src/instructions/admin/collect_fund_fee.rs
+++ b/programs/cp-swap/src/instructions/admin/collect_fund_fee.rs
@@ -2,10 +2,10 @@ use crate::error::ErrorCode;
 use crate::states::*;
 use crate::utils::token::*;
 use anchor_lang::prelude::*;
-use light_token_sdk::anchor::anchor_spl::token::Token;
-use light_token_sdk::anchor::anchor_spl::token_interface::Mint;
-use light_token_sdk::anchor::anchor_spl::token_interface::Token2022;
-use light_token_sdk::anchor::anchor_spl::token_interface::TokenAccount;
+use light_anchor_spl::token::Token;
+use light_anchor_spl::token_interface::Mint;
+use light_anchor_spl::token_interface::Token2022;
+use light_anchor_spl::token_interface::TokenAccount;
 #[derive(Accounts)]
 pub struct CollectFundFee<'info> {
     /// Only admin or fund_owner can collect fee now

--- a/programs/cp-swap/src/instructions/admin/collect_protocol_fee.rs
+++ b/programs/cp-swap/src/instructions/admin/collect_protocol_fee.rs
@@ -2,10 +2,10 @@ use crate::error::ErrorCode;
 use crate::states::*;
 use crate::utils::*;
 use anchor_lang::prelude::*;
-use light_token_sdk::anchor::anchor_spl::token::Token;
-use light_token_sdk::anchor::anchor_spl::token_interface::Mint;
-use light_token_sdk::anchor::anchor_spl::token_interface::Token2022;
-use light_token_sdk::anchor::anchor_spl::token_interface::TokenAccount;
+use light_anchor_spl::token::Token;
+use light_anchor_spl::token_interface::Mint;
+use light_anchor_spl::token_interface::Token2022;
+use light_anchor_spl::token_interface::TokenAccount;
 
 #[derive(Accounts)]
 pub struct CollectProtocolFee<'info> {

--- a/programs/cp-swap/src/instructions/deposit.rs
+++ b/programs/cp-swap/src/instructions/deposit.rs
@@ -4,10 +4,10 @@ use crate::error::ErrorCode;
 use crate::states::*;
 use crate::utils::token::*;
 use anchor_lang::prelude::*;
-use light_token_sdk::anchor::anchor_spl::token::Token;
-use light_token_sdk::anchor::anchor_spl::token_interface::Token2022;
-use light_token_sdk::token::MintToCpi;
-use light_token_sdk::anchor::anchor_spl::token_interface::{TokenAccount, Mint,TokenInterface};
+use light_anchor_spl::token::Token;
+use light_anchor_spl::token_interface::Token2022;
+use light_token::instruction::MintToCpi;
+use light_anchor_spl::token_interface::{TokenAccount, Mint,TokenInterface};
 
 #[derive(Accounts)]
 pub struct Deposit<'info> {

--- a/programs/cp-swap/src/instructions/initialize.rs
+++ b/programs/cp-swap/src/instructions/initialize.rs
@@ -7,16 +7,16 @@ use anchor_lang::{
     prelude::*,
     solana_program::{clock, program::invoke, system_instruction},
 };
-use light_token_sdk::anchor::anchor_spl::{
+use light_anchor_spl::{
     associated_token::AssociatedToken,
     token::spl_token,
     token::Token,
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 use light_sdk::interface::CreateAccountsProof;
-use light_token_sdk::anchor::LightAccounts;
-use light_token_sdk::{
-    token::{
+use light_token::anchor::LightAccounts;
+use light_token::{
+    instruction::{
         CreateTokenAccountCpi, CreateTokenAtaCpi, MintToCpi, COMPRESSIBLE_CONFIG_V1,
         RENT_SPONSOR as LIGHT_TOKEN_RENT_SPONSOR,
     },

--- a/programs/cp-swap/src/instructions/swap_base_input.rs
+++ b/programs/cp-swap/src/instructions/swap_base_input.rs
@@ -5,7 +5,7 @@ use crate::states::*;
 use crate::utils::token::*;
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
-use light_token_sdk::anchor::anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
+use light_anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 #[derive(Accounts)]
 pub struct Swap<'info> {

--- a/programs/cp-swap/src/instructions/withdraw.rs
+++ b/programs/cp-swap/src/instructions/withdraw.rs
@@ -4,12 +4,12 @@ use crate::error::ErrorCode;
 use crate::states::*;
 use crate::utils::token::*;
 use anchor_lang::prelude::*;
-use light_token_sdk::anchor::anchor_spl::{
+use light_anchor_spl::{
     memo::spl_memo,
     token::Token,
     token_interface::{Mint, Token2022, TokenAccount, TokenInterface},
 };
-use light_token_sdk::token::BurnCpi;
+use light_token::instruction::BurnCpi;
 
 #[derive(Accounts)]
 pub struct Withdraw<'info> {

--- a/programs/cp-swap/src/lib.rs
+++ b/programs/cp-swap/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::states::{
 };
 use anchor_lang::prelude::*;
 use instructions::*;
-use light_token_sdk::anchor::{
+use light_token::anchor::{
     derive_light_cpi_signer, derive_light_rent_sponsor_pda, light_program, CpiSigner,
 };
 

--- a/programs/cp-swap/src/states/oracle.rs
+++ b/programs/cp-swap/src/states/oracle.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use light_sdk::LightDiscriminator;
-use light_token_sdk::anchor::{CompressionInfo, LightAccount};
+use light_token::anchor::{CompressionInfo, LightAccount};
 
 #[cfg(test)]
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/programs/cp-swap/src/states/pool.rs
+++ b/programs/cp-swap/src/states/pool.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
-use light_token_sdk::anchor::anchor_spl::token_interface::Mint;
+use light_anchor_spl::token_interface::Mint;
 use light_sdk::LightDiscriminator;
-use light_token_sdk::anchor::{CompressionInfo, LightAccount};
+use light_token::anchor::{CompressionInfo, LightAccount};
 use std::ops::{BitAnd, BitOr, BitXor};
 
 pub const POOL_SEED: &str = "pool";

--- a/programs/cp-swap/src/utils/token.rs
+++ b/programs/cp-swap/src/utils/token.rs
@@ -1,12 +1,12 @@
 use crate::error::ErrorCode;
 use anchor_lang::{prelude::*, system_program};
-use light_token_sdk::anchor::anchor_spl::{
+use light_anchor_spl::{
     token::{Token, TokenAccount},
     token_2022,
     token_interface::{initialize_account3, InitializeAccount3, Mint},
 };
 use light_sdk::constants::LIGHT_TOKEN_PROGRAM_ID;
-use light_token_sdk::token::TransferInterfaceCpi;
+use light_token::instruction::TransferInterfaceCpi;
 use spl_token_2022::{
     self,
     extension::{

--- a/programs/cp-swap/tests/helpers.rs
+++ b/programs/cp-swap/tests/helpers.rs
@@ -13,9 +13,9 @@ use light_program_test::{
     program_test::{setup_mock_program_data, LightProgramTest, TestRpc},
     Indexer, ProgramTestConfig, Rpc,
 };
-use light_token_sdk::{
+use light_token::{
     constants::CPI_AUTHORITY_PDA,
-    token::{
+    instruction::{
         find_mint_address, get_associated_token_address_and_bump, CreateAssociatedTokenAccount,
         CreateMint, CreateMintParams, MintTo, COMPRESSIBLE_CONFIG_V1,
         RENT_SPONSOR as LIGHT_TOKEN_RENT_SPONSOR,
@@ -32,7 +32,7 @@ use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use solana_sdk::{program_pack::Pack, signature::SeedDerivable};
-use light_token_sdk::anchor::anchor_spl::memo::spl_memo;
+use light_anchor_spl::memo::spl_memo;
 use spl_token_2022;
 
 
@@ -129,7 +129,7 @@ pub async fn setup_create_mint(
     let address_tree = rpc.get_address_tree_v2();
     let output_queue = rpc.get_random_state_tree_info().unwrap().queue;
 
-    let compression_address = light_token_sdk::token::derive_mint_compressed_address(
+    let compression_address = light_token::instruction::derive_mint_compressed_address(
         &mint_seed.pubkey(),
         &address_tree.tree,
     );
@@ -628,7 +628,7 @@ pub fn build_initialize_instruction(
         token_program: spl_token::id(),
         token_0_program: light_token_program_id(),
         token_1_program: light_token_program_id(),
-        associated_token_program: light_token_sdk::anchor::anchor_spl::associated_token::ID,
+        associated_token_program: light_anchor_spl::associated_token::ID,
         system_program: solana_sdk::system_program::ID,
         rent: solana_sdk::sysvar::rent::ID,
         compression_config: config_pda,

--- a/programs/cp-swap/tests/program.rs
+++ b/programs/cp-swap/tests/program.rs
@@ -13,7 +13,7 @@ use light_client::interface::{
     TokenAccountInterface,
 };
 use light_sdk::LightDiscriminator;
-use light_token_sdk::compat::{CTokenData, TokenData};
+use light_token::compat::{CTokenData, TokenData};
 use raydium_cp_swap::instructions::initialize::LP_MINT_SIGNER_SEED;
 use raydium_cp_swap::{
     raydium_cp_swap::{LightAccountVariant, TokenAccountVariant},
@@ -203,7 +203,7 @@ impl CpSwapSdk {
             } else {
                 None
             },
-            state: light_token_sdk::compat::AccountState::Initialized,
+            state: light_token::compat::AccountState::Initialized,
             tlv: None,
         };
 


### PR DESCRIPTION
- Update light-sdk to 0.18.0
- Update light-token to 0.3.0
- Update light-program-test to 0.18.0
- Update light-client to 0.18.0
- Add light-hasher 5
- Add light-anchor-spl 0.31.1
- Remove v2 feature flags (now default)